### PR TITLE
Fix default role in user registration

### DIFF
--- a/server/services/UserService.ts
+++ b/server/services/UserService.ts
@@ -32,13 +32,20 @@ export class UserService {
     const hashedPassword = await bcrypt.hash(password, saltRounds);
 
     // 3. Создаём пользователя
+    // Убеждаемся, что дефолтная роль существует
+    const defaultRole = await prisma.role.upsert({
+      where: { role: 'USER' },
+      update: {},
+      create: { role: 'USER' },
+    });
+
     const user = await prisma.user.create({
       data: {
         username,
         email,
         password: hashedPassword,
-        // По умолчанию даём роль с id = 1
-        roleId: 1,
+        // По умолчанию даём базовую роль
+        roleId: defaultRole.id,
       },
       select: {
         id: true,


### PR DESCRIPTION
## Summary
- ensure default `USER` role exists when registering

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684160eabe648320b4ad80754fe0caa1