### PR TITLE
Fix dark theme for form fields

### DIFF
--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import NavBar from "@/components/NavBarClient";
 import { AuthProvider } from "@/context/AuthContext";
+import ThemeRegistry from "@/components/ThemeRegistry";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -16,10 +17,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <AuthProvider>
-          <NavBar />
-          {children}
-        </AuthProvider>
+        <ThemeRegistry>
+          <AuthProvider>
+            <NavBar />
+            {children}
+          </AuthProvider>
+        </ThemeRegistry>
       </body>
     </html>
   );

--- a/client/src/components/ThemeRegistry.tsx
+++ b/client/src/components/ThemeRegistry.tsx
@@ -1,0 +1,26 @@
+'use client';
+import * as React from 'react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+export default function ThemeRegistry({ children }: { children: React.ReactNode }) {
+  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+
+  const theme = React.useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode: prefersDarkMode ? 'dark' : 'light',
+        },
+      }),
+    [prefersDarkMode]
+  );
+
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- add MUI ThemeRegistry to sync with prefers-color-scheme
- wrap app with ThemeRegistry so MUI components show text properly in dark mode

## Testing
- `npm run lint` *(fails: asks ESLint configuration)*
- `npm run build` in `server`

------
https://chatgpt.com/codex/tasks/task_e_68416d6cd6c4832096e9bac12c2325f1