### PR TITLE
Add file management features

### DIFF
--- a/client/src/api/file.ts
+++ b/client/src/api/file.ts
@@ -1,0 +1,29 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api';
+
+export async function uploadFile(formData: FormData, token: string) {
+  const res = await fetch(`${API_URL}/files/upload`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData,
+  });
+  if (!res.ok) throw new Error('Failed');
+  return res.json();
+}
+
+export async function listFiles(query: string, token: string) {
+  const url = new URL(`${API_URL}/files`);
+  if (query) url.searchParams.set('q', query);
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed');
+  return res.json();
+}
+
+export async function listCategories(token: string) {
+  const res = await fetch(`${API_URL}/files/categories`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed');
+  return res.json();
+}

--- a/client/src/app/dashboard/files/page.tsx
+++ b/client/src/app/dashboard/files/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import { listFiles } from '@/api/file';
+import { useRouter } from 'next/navigation';
+import { Container, Typography, TextField, Box, List, ListItem, ListItemText, Button } from '@mui/material';
+
+export default function FilesPage() {
+  const { auth } = useAuth();
+  const router = useRouter();
+  const [query, setQuery] = useState('');
+  const [files, setFiles] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (!auth.user) {
+      router.replace('/login');
+    } else {
+      listFiles('', auth.token || '').then(setFiles).catch(() => {});
+    }
+  }, [auth, router]);
+
+  if (!auth.user) return null;
+
+  const search = async () => {
+    const res = await listFiles(query, auth.token || '');
+    setFiles(res);
+  };
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Typography variant="h5" gutterBottom>
+        Files
+      </Typography>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+        <TextField label="Search" value={query} onChange={(e) => setQuery(e.target.value)} />
+        <Button variant="contained" onClick={search}>Search</Button>
+      </Box>
+      <List>
+        {files.map((f) => (
+          <ListItem key={f.id}>
+            <ListItemText primary={f.filename} secondary={f.categories.map((c: any) => c.category.name).join(', ')} />
+          </ListItem>
+        ))}
+      </List>
+    </Container>
+  );
+}

--- a/client/src/app/dashboard/upload/page.tsx
+++ b/client/src/app/dashboard/upload/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import { useRouter } from 'next/navigation';
+import { uploadFile, listCategories } from '@/api/file';
+import { Container, Typography, TextField, Button, Box, Select, MenuItem } from '@mui/material';
+
+export default function UploadPage() {
+  const { auth } = useAuth();
+  const router = useRouter();
+  const [file, setFile] = useState<File | null>(null);
+  const [categories, setCategories] = useState<any[]>([]);
+  const [selected, setSelected] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (!auth.user) {
+      router.replace('/login');
+    } else {
+      listCategories(auth.token || '').then(setCategories).catch(() => {});
+    }
+  }, [auth, router]);
+
+  if (!auth.user) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    const fd = new FormData();
+    fd.append('file', file);
+    fd.append('categories', selected.join(','));
+    await uploadFile(fd, auth.token || '');
+    router.push('/dashboard/files');
+  };
+
+  return (
+    <Container sx={{ mt: 4 }} maxWidth="sm">
+      <Typography variant="h5" gutterBottom>
+        Upload File
+      </Typography>
+      <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        <Select multiple value={selected} onChange={(e) => setSelected(e.target.value as number[])}>
+          {categories.map((cat) => (
+            <MenuItem key={cat.id} value={cat.id}>{cat.name}</MenuItem>
+          ))}
+        </Select>
+        <Button type="submit" variant="contained">
+          Upload
+        </Button>
+      </Box>
+    </Container>
+  );
+}

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -25,6 +25,12 @@ export default function NavBar() {
             <Button color="inherit" component={Link} href="/dashboard">
               Dashboard
             </Button>
+            <Button color="inherit" component={Link} href="/dashboard/upload">
+              Upload
+            </Button>
+            <Button color="inherit" component={Link} href="/dashboard/files">
+              Files
+            </Button>
             <Button color="inherit" onClick={handleLogout}>Logout</Button>
           </React.Fragment>
         ) : (

--- a/server/.env
+++ b/server/.env
@@ -13,3 +13,7 @@ PORT="5000"
 
 DATABASE_URL="postgresql://user:pass@localhost:5432/mydb?schema=public"
 JWT_SECRET="I6AU1WGD^!$HFA4D*12735*&%$"
+S3_ENDPOINT="http://localhost:9000"
+S3_ACCESS_KEY="minio"
+S3_SECRET_KEY="minio123"
+S3_BUCKET="uploads"

--- a/server/controllers/CategoryController.ts
+++ b/server/controllers/CategoryController.ts
@@ -1,0 +1,28 @@
+import { Request, Response } from 'express';
+import { CategoryService } from '../services/CategoryService';
+
+export class CategoryController {
+  static async list(_req: Request, res: Response) {
+    const categories = await CategoryService.list();
+    res.json(categories);
+  }
+
+  static async create(req: Request, res: Response) {
+    const { name } = req.body;
+    const category = await CategoryService.create(name);
+    res.status(201).json(category);
+  }
+
+  static async update(req: Request, res: Response) {
+    const id = parseInt(req.params.id);
+    const { name } = req.body;
+    const category = await CategoryService.update(id, name);
+    res.json(category);
+  }
+
+  static async remove(req: Request, res: Response) {
+    const id = parseInt(req.params.id);
+    await CategoryService.remove(id);
+    res.status(204).end();
+  }
+}

--- a/server/controllers/FileController.ts
+++ b/server/controllers/FileController.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express';
+import { FileService } from '../services/FileService';
+
+export class FileController {
+  static async upload(req: Request, res: Response): Promise<void> {
+    const file = (req as any).file as Express.Multer.File | undefined;
+    if (!file) {
+      res.status(400).json({ error: 'No file' });
+      return;
+    }
+    const categoryIds = (req.body.categories || '')
+      .split(',')
+      .map((v: string) => parseInt(v))
+      .filter((v: number) => !isNaN(v));
+    const userId = (req as any).userId as number | undefined;
+    const created = await FileService.upload(file.originalname, file.buffer, userId, categoryIds);
+    res.json(created);
+  }
+
+  static async list(req: Request, res: Response): Promise<void> {
+    const q = req.query.q as string | undefined;
+    const files = await FileService.list(q);
+    res.json(files);
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import cors from 'cors';
 import bodyParser from 'body-parser';
 import userRoutes from './route/UserRoutes';
+import fileRoutes from './route/FileRoutes';
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './swagger';
 
@@ -19,6 +20,7 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // Подключаем роуты
 app.use('/api/user', userRoutes);
+app.use('/api/files', fileRoutes);
 
 // Глобальный обработчик ошибок (на будущее)
 app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/server/package.json
+++ b/server/package.json
@@ -5,13 +5,15 @@
   "scripts": {
     "build": "npx tsc",
     "start": "node dist/index.js",
-    "dev": "nodemon index.ts"
+    "dev": "nodemon index.ts",
+    "seed": "ts-node-dev prisma/seed.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.599.0",
     "@prisma/client": "^6.9.0",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
@@ -19,10 +21,12 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
+    "multer": "1.4.5-lts.2",
     "nodemon": "^3.1.10",
     "prisma": "^6.9.0",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
@@ -30,8 +34,11 @@
     "@types/express": "^5.0.2",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/knex": "^0.15.2",
+    "@types/multer": "^1.4.12",
+    "@types/node": "^20.11.17",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",
+    "@types/uuid": "^10.0.0",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.8.3"
   }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -52,3 +52,35 @@ model RolePermission {
   @@map("RolePermissions")
   @@unique([roleId, permissionId])
 }
+
+model File {
+  id        Int       @id @default(autoincrement())
+  key       String    @unique
+  filename  String
+  userId    Int?
+  user      User?     @relation(fields: [userId], references: [id])
+  createdAt DateTime  @default(now())
+  categories FileCategory[]
+
+  @@map("Files")
+}
+
+model Category {
+  id    Int           @id @default(autoincrement())
+  name  String        @unique
+  files FileCategory[]
+
+  @@map("Categories")
+}
+
+model FileCategory {
+  id         Int      @id @default(autoincrement())
+  fileId     Int
+  categoryId Int
+
+  file     File     @relation(fields: [fileId], references: [id])
+  category Category @relation(fields: [categoryId], references: [id])
+
+  @@map("FileCategories")
+  @@unique([fileId, categoryId])
+}

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,0 +1,76 @@
+import bcrypt from 'bcrypt';
+import prisma from './client';
+
+async function main() {
+  // roles
+  const superadminRole = await prisma.role.upsert({
+    where: { role: 'SUPERADMIN' },
+    update: {},
+    create: { role: 'SUPERADMIN' },
+  });
+  const adminRole = await prisma.role.upsert({
+    where: { role: 'ADMIN' },
+    update: {},
+    create: { role: 'ADMIN' },
+  });
+  const userRole = await prisma.role.upsert({
+    where: { role: 'USER' },
+    update: {},
+    create: { role: 'USER' },
+  });
+
+  // permissions
+  const permissions = ['FILE_UPLOAD', 'FILE_EDIT', 'FILE_DELETE', 'USER_MANAGE', 'USER_DELETE_SOFT', 'USER_DELETE_FORCE'];
+  const permissionRecords = await Promise.all(
+    permissions.map((p) =>
+      prisma.permission.upsert({ where: { permission: p }, update: {}, create: { permission: p } })
+    )
+  );
+
+  // role permissions
+  const permissionMap: Record<string, number> = Object.fromEntries(permissionRecords.map((p) => [p.permission, p.id]));
+
+  // admin + superadmin for upload edit delete
+  const adminPermissions = ['FILE_UPLOAD', 'FILE_EDIT', 'FILE_DELETE', 'USER_DELETE_SOFT'];
+  for (const perm of adminPermissions) {
+    await prisma.rolePermission.upsert({
+      where: { roleId_permissionId: { roleId: adminRole.id, permissionId: permissionMap[perm] } },
+      update: {},
+      create: { roleId: adminRole.id, permissionId: permissionMap[perm] },
+    });
+  }
+  const superPerms = [...adminPermissions, 'USER_MANAGE', 'USER_DELETE_FORCE'];
+  for (const perm of superPerms) {
+    await prisma.rolePermission.upsert({
+      where: { roleId_permissionId: { roleId: superadminRole.id, permissionId: permissionMap[perm] } },
+      update: {},
+      create: { roleId: superadminRole.id, permissionId: permissionMap[perm] },
+    });
+  }
+  // user only upload
+  await prisma.rolePermission.upsert({
+    where: { roleId_permissionId: { roleId: userRole.id, permissionId: permissionMap['FILE_UPLOAD'] } },
+    update: {},
+    create: { roleId: userRole.id, permissionId: permissionMap['FILE_UPLOAD'] },
+  });
+
+  // default superadmin
+  const hashedPassword = await bcrypt.hash('superadmin', 10);
+  await prisma.user.upsert({
+    where: { email: 'super@admin.com' },
+    update: {},
+    create: {
+      username: 'superadmin',
+      email: 'super@admin.com',
+      password: hashedPassword,
+      roleId: superadminRole.id,
+    },
+  });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+}).finally(async () => {
+  await prisma.$disconnect();
+});

--- a/server/route/FileRoutes.ts
+++ b/server/route/FileRoutes.ts
@@ -1,0 +1,69 @@
+import { Router } from 'express';
+import multer from 'multer';
+import { FileController } from '../controllers/FileController';
+import { CategoryController } from '../controllers/CategoryController';
+import { authMiddleware } from '../utils/authMiddleware';
+
+const router = Router();
+const upload = multer();
+
+/**
+ * @swagger
+ * /api/files/upload:
+ *   post:
+ *     summary: Upload file
+ *     tags: [File]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *               categories:
+ *                 type: string
+ *                 description: Comma separated category ids
+ *     responses:
+ *       200:
+ *         description: Uploaded
+ */
+router.post('/upload', authMiddleware as any, upload.single('file'), FileController.upload);
+
+/**
+ * @swagger
+ * /api/files:
+ *   get:
+ *     summary: List files
+ *     tags: [File]
+ *     parameters:
+ *       - in: query
+ *         name: q
+ *         schema:
+ *           type: string
+ *         description: Search by filename
+ *     responses:
+ *       200:
+ *         description: List files
+ */
+router.get('/', authMiddleware as any, FileController.list);
+
+/**
+ * @swagger
+ * /api/categories:
+ *   get:
+ *     summary: List categories
+ *     tags: [Category]
+ *     responses:
+ *       200:
+ *         description: List
+ */
+router.get('/categories', authMiddleware as any, CategoryController.list);
+
+router.post('/categories', authMiddleware as any, CategoryController.create);
+router.put('/categories/:id', authMiddleware as any, CategoryController.update);
+router.delete('/categories/:id', authMiddleware as any, CategoryController.remove);
+
+export default router;

--- a/server/services/CategoryService.ts
+++ b/server/services/CategoryService.ts
@@ -1,0 +1,19 @@
+import prisma from '../prisma/client';
+
+export class CategoryService {
+  static list() {
+    return prisma.category.findMany({ orderBy: { name: 'asc' } });
+  }
+
+  static async create(name: string) {
+    return prisma.category.create({ data: { name } });
+  }
+
+  static async update(id: number, name: string) {
+    return prisma.category.update({ where: { id }, data: { name } });
+  }
+
+  static async remove(id: number) {
+    return prisma.category.delete({ where: { id } });
+  }
+}

--- a/server/services/FileService.ts
+++ b/server/services/FileService.ts
@@ -1,0 +1,30 @@
+import prisma from '../prisma/client';
+import { uploadToS3 } from './S3Service';
+import { v4 as uuidv4 } from 'uuid';
+
+export class FileService {
+  static async upload(filename: string, buffer: Buffer, userId: number | undefined, categories: number[]) {
+    const key = uuidv4();
+    await uploadToS3(key, buffer);
+    const file = await prisma.file.create({
+      data: {
+        key,
+        filename,
+        userId,
+        categories: {
+          create: categories.map((categoryId) => ({ categoryId })),
+        },
+      },
+      include: { categories: { include: { category: true } } },
+    });
+    return file;
+  }
+
+  static async list(search?: string) {
+    return prisma.file.findMany({
+      where: search ? { filename: { contains: search, mode: 'insensitive' } } : {},
+      include: { categories: { include: { category: true } } },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+}

--- a/server/services/S3Service.ts
+++ b/server/services/S3Service.ts
@@ -1,0 +1,19 @@
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const s3 = new S3Client({
+  region: 'us-east-1',
+  endpoint: process.env.S3_ENDPOINT,
+  credentials: {
+    accessKeyId: process.env.S3_ACCESS_KEY || '',
+    secretAccessKey: process.env.S3_SECRET_KEY || '',
+  },
+  forcePathStyle: true,
+});
+
+export async function uploadToS3(key: string, body: Buffer) {
+  const cmd = new PutObjectCommand({ Bucket: process.env.S3_BUCKET, Key: key, Body: body });
+  await s3.send(cmd);
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -11,7 +11,8 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2019",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["es2019"],
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "libReplacement": true,                           /* Enable lib replacement. */
@@ -28,12 +29,13 @@
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"],
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/server/utils/authMiddleware.ts
+++ b/server/utils/authMiddleware.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from 'express';
+import { verifyToken } from './auth';
+
+export function authMiddleware(req: Request, res: Response, next: NextFunction) {
+  const auth = req.headers.authorization;
+  if (!auth) return res.status(401).json({ error: 'Unauthorized' });
+  const token = auth.split(' ')[1];
+  try {
+    const payload = verifyToken(token);
+    (req as any).userId = payload.userId;
+    next();
+  } catch {
+    res.status(401).json({ error: 'Unauthorized' });
+  }
+}


### PR DESCRIPTION
## Summary
- seed default roles/permissions and a super admin user
- integrate S3 storage uploads
- add API endpoints for file and category management
- expose upload and files pages in dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684171eac500832091cebe7738f61918