### PR TITLE
Fix bucket initialization for minio

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,17 @@ services:
     ports:
       - "9000:9000"
 
+  minio-init:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+        until (/usr/bin/mc alias set local http://minio:9000 minio minio123); do echo 'waiting for minio' && sleep 1; done;
+        /usr/bin/mc mb --ignore-existing local/uploads;
+        exit 0;
+      "
+
 volumes:
   db-data:
   minio-data:


### PR DESCRIPTION
## Summary
- add minio-init service in `docker-compose.yml` to automatically create the `uploads` bucket

## Testing
- `npm install` in `server`
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68417d316fe08320820f26ed51d048fb