### PR TITLE
Add file download & admin controls

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1145,7 +1145,6 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"

--- a/client/src/api/file.ts
+++ b/client/src/api/file.ts
@@ -27,3 +27,21 @@ export async function listCategories(token: string) {
   if (!res.ok) throw new Error('Failed');
   return res.json();
 }
+
+export async function downloadFile(id: number, token: string) {
+  const res = await fetch(`${API_URL}/files/${id}/download`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed');
+  return res.blob();
+}
+
+export async function deleteFile(id: number, token: string, force = false) {
+  const url = new URL(`${API_URL}/files/${id}`);
+  if (force) url.searchParams.set('force', 'true');
+  const res = await fetch(url.toString(), {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed');
+}

--- a/client/src/app/dashboard/files/page.tsx
+++ b/client/src/app/dashboard/files/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useAuth } from '@/context/AuthContext';
-import { listFiles } from '@/api/file';
+import { listFiles, downloadFile, deleteFile } from '@/api/file';
 import { useRouter } from 'next/navigation';
 import { Container, Typography, TextField, Box, List, ListItem, ListItemText, Button } from '@mui/material';
 
@@ -39,6 +39,21 @@ export default function FilesPage() {
         {files.map((f) => (
           <ListItem key={f.id}>
             <ListItemText primary={f.filename} secondary={f.categories.map((c: any) => c.category.name).join(', ')} />
+            <Button onClick={async () => {
+              const blob = await downloadFile(f.id, auth.token || '');
+              const url = window.URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = f.filename;
+              a.click();
+              window.URL.revokeObjectURL(url);
+            }}>Download</Button>
+            {(auth.user && (auth.user.role === 'ADMIN' || auth.user.role === 'SUPERADMIN')) && (
+              <Button onClick={async () => {
+                await deleteFile(f.id, auth.token || '', auth.user?.role === 'SUPERADMIN');
+                setFiles(files.filter((x) => x.id !== f.id));
+              }}>Delete</Button>
+            )}
           </ListItem>
         ))}
       </List>

--- a/server/controllers/CategoryController.ts
+++ b/server/controllers/CategoryController.ts
@@ -7,20 +7,32 @@ export class CategoryController {
     res.json(categories);
   }
 
-  static async create(req: Request, res: Response) {
+  static async create(req: Request, res: Response): Promise<void> {
+    if ((req as any).userRole !== 'SUPERADMIN') {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
     const { name } = req.body;
     const category = await CategoryService.create(name);
     res.status(201).json(category);
   }
 
-  static async update(req: Request, res: Response) {
+  static async update(req: Request, res: Response): Promise<void> {
+    if ((req as any).userRole !== 'SUPERADMIN') {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
     const id = parseInt(req.params.id);
     const { name } = req.body;
     const category = await CategoryService.update(id, name);
     res.json(category);
   }
 
-  static async remove(req: Request, res: Response) {
+  static async remove(req: Request, res: Response): Promise<void> {
+    if ((req as any).userRole !== 'SUPERADMIN') {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
     const id = parseInt(req.params.id);
     await CategoryService.remove(id);
     res.status(204).end();

--- a/server/controllers/FileController.ts
+++ b/server/controllers/FileController.ts
@@ -22,4 +22,26 @@ export class FileController {
     const files = await FileService.list(q);
     res.json(files);
   }
+
+  static async download(req: Request, res: Response): Promise<void> {
+    const id = parseInt(req.params.id);
+    const result = await FileService.download(id);
+    if (!result) {
+      res.status(404).end();
+      return;
+    }
+    res.setHeader('Content-Disposition', `attachment; filename="${result.file.filename}"`);
+    res.send(Buffer.from(result.data));
+  }
+
+  static async delete(req: Request, res: Response): Promise<void> {
+    const id = parseInt(req.params.id);
+    const role = (req as any).userRole;
+    if (role === 'SUPERADMIN' && req.query.force === 'true') {
+      await FileService.forceDelete(id);
+    } else {
+      await FileService.softDelete(id);
+    }
+    res.status(204).end();
+  }
 }

--- a/server/prisma/migrations/20250605113000_add_deletedat/migration.sql
+++ b/server/prisma/migrations/20250605113000_add_deletedat/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Files" ADD COLUMN "deletedAt" TIMESTAMP(3);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -61,6 +61,7 @@ model File {
   userId     Int?
   user       User?          @relation(fields: [userId], references: [id])
   createdAt  DateTime       @default(now())
+  deletedAt  DateTime?
   categories FileCategory[]
 
   @@map("Files")

--- a/server/route/FileRoutes.ts
+++ b/server/route/FileRoutes.ts
@@ -49,6 +49,8 @@ router.post('/upload', authMiddleware as any, upload.single('file'), FileControl
  *         description: List files
  */
 router.get('/', authMiddleware as any, FileController.list);
+router.get('/:id/download', authMiddleware as any, FileController.download);
+router.delete('/:id', authMiddleware as any, FileController.delete);
 
 /**
  * @swagger

--- a/server/services/FileService.ts
+++ b/server/services/FileService.ts
@@ -1,5 +1,5 @@
 import prisma from '../prisma/client';
-import { uploadToS3 } from './S3Service';
+import { uploadToS3, downloadFromS3, deleteFromS3 } from './S3Service';
 import { v4 as uuidv4 } from 'uuid';
 
 export class FileService {
@@ -22,9 +22,41 @@ export class FileService {
 
   static async list(search?: string) {
     return prisma.file.findMany({
-      where: search ? { filename: { contains: search, mode: 'insensitive' } } : {},
+      where: {
+        deletedAt: null,
+        ...(search
+          ? { filename: { contains: search, mode: 'insensitive' } }
+          : {}),
+      },
       include: { categories: { include: { category: true } } },
       orderBy: { createdAt: 'desc' },
     });
+  }
+
+  static async get(id: number) {
+    return prisma.file.findUnique({
+      where: { id, deletedAt: null },
+    });
+  }
+
+  static async download(id: number) {
+    const file = await prisma.file.findUnique({ where: { id } });
+    if (!file) return null;
+    const data = await downloadFromS3(file.key);
+    return { file, data };
+  }
+
+  static async softDelete(id: number) {
+    await prisma.file.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+
+  static async forceDelete(id: number) {
+    const f = await prisma.file.findUnique({ where: { id } });
+    if (!f) return;
+    await deleteFromS3(f.key);
+    await prisma.file.delete({ where: { id } });
   }
 }

--- a/server/services/S3Service.ts
+++ b/server/services/S3Service.ts
@@ -1,4 +1,4 @@
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand, GetObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -15,5 +15,17 @@ const s3 = new S3Client({
 
 export async function uploadToS3(key: string, body: Buffer) {
   const cmd = new PutObjectCommand({ Bucket: process.env.S3_BUCKET, Key: key, Body: body });
+  await s3.send(cmd);
+}
+
+export async function downloadFromS3(key: string): Promise<Uint8Array> {
+  const cmd = new GetObjectCommand({ Bucket: process.env.S3_BUCKET, Key: key });
+  const resp = await s3.send(cmd);
+  const body = await resp.Body?.transformToByteArray();
+  return body || new Uint8Array();
+}
+
+export async function deleteFromS3(key: string) {
+  const cmd = new DeleteObjectCommand({ Bucket: process.env.S3_BUCKET, Key: key });
   await s3.send(cmd);
 }

--- a/server/utils/authMiddleware.ts
+++ b/server/utils/authMiddleware.ts
@@ -8,6 +8,7 @@ export function authMiddleware(req: Request, res: Response, next: NextFunction) 
   try {
     const payload = verifyToken(token);
     (req as any).userId = payload.userId;
+    (req as any).userRole = payload.role;
     next();
   } catch {
     res.status(401).json({ error: 'Unauthorized' });


### PR DESCRIPTION
## Summary
- restrict category management to superadmins only
- set user role in auth middleware
- support file download, soft delete, and force delete
- allow admins to remove files and users to download them
- add client helpers for download and delete
- update dashboard page with download/delete buttons
- track soft deletions in prisma schema and migration

## Testing
- `npm run build` in `server`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68417f5026908320b335865434b3ab44