### PR TITLE
Add categories admin UI

### DIFF
--- a/client/src/api/category.ts
+++ b/client/src/api/category.ts
@@ -1,0 +1,43 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api';
+
+export async function listCategories(token: string) {
+  const res = await fetch(`${API_URL}/files/categories`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed');
+  return res.json();
+}
+
+export async function createCategory(name: string, token: string) {
+  const res = await fetch(`${API_URL}/files/categories`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) throw new Error('Failed');
+  return res.json();
+}
+
+export async function updateCategory(id: number, name: string, token: string) {
+  const res = await fetch(`${API_URL}/files/categories/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) throw new Error('Failed');
+  return res.json();
+}
+
+export async function deleteCategory(id: number, token: string) {
+  const res = await fetch(`${API_URL}/files/categories/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed');
+}

--- a/client/src/api/file.ts
+++ b/client/src/api/file.ts
@@ -20,13 +20,6 @@ export async function listFiles(query: string, token: string) {
   return res.json();
 }
 
-export async function listCategories(token: string) {
-  const res = await fetch(`${API_URL}/files/categories`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) throw new Error('Failed');
-  return res.json();
-}
 
 export async function downloadFile(id: number, token: string) {
   const res = await fetch(`${API_URL}/files/${id}/download`, {

--- a/client/src/app/dashboard/categories/page.tsx
+++ b/client/src/app/dashboard/categories/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/context/AuthContext';
+import {
+  listCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} from '@/api/category';
+import {
+  Container,
+  Typography,
+  TextField,
+  Button,
+  Box,
+  List,
+  ListItem,
+  ListItemText,
+} from '@mui/material';
+
+export default function CategoriesPage() {
+  const { auth } = useAuth();
+  const router = useRouter();
+  const [categories, setCategories] = useState<any[]>([]);
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    if (!auth.user) {
+      router.replace('/login');
+    } else {
+      listCategories(auth.token || '').then(setCategories).catch(() => {});
+    }
+  }, [auth, router]);
+
+  if (!auth.user) return null;
+
+  const refresh = async () => {
+    const cats = await listCategories(auth.token || '');
+    setCategories(cats);
+  };
+
+  const add = async () => {
+    await createCategory(name, auth.token || '');
+    setName('');
+    refresh();
+  };
+
+  const edit = async (id: number, current: string) => {
+    const value = prompt('New name', current);
+    if (value && value !== current) {
+      await updateCategory(id, value, auth.token || '');
+      setCategories(categories.map((c) => (c.id === id ? { ...c, name: value } : c)));
+    }
+  };
+
+  const remove = async (id: number) => {
+    if (confirm('Delete category?')) {
+      await deleteCategory(id, auth.token || '');
+      setCategories(categories.filter((c) => c.id !== id));
+    }
+  };
+
+  return (
+    <Container sx={{ mt: 4 }}>
+      <Typography variant="h5" gutterBottom>
+        Categories
+      </Typography>
+      {auth.user.role === 'SUPERADMIN' && (
+        <Box sx={{ display: 'flex', gap: 2, mb: 2 }}>
+          <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+          <Button variant="contained" onClick={add} disabled={!name.trim()}>
+            Add
+          </Button>
+        </Box>
+      )}
+      <List>
+        {categories.map((c) => (
+          <ListItem key={c.id} secondaryAction={
+            auth.user?.role === 'SUPERADMIN' ? (
+              <Box sx={{ display: 'flex', gap: 1 }}>
+                <Button onClick={() => edit(c.id, c.name)}>Edit</Button>
+                <Button onClick={() => remove(c.id)}>Delete</Button>
+              </Box>
+            ) : null
+          }>
+            <ListItemText primary={c.name} />
+          </ListItem>
+        ))}
+      </List>
+    </Container>
+  );
+}

--- a/client/src/app/dashboard/upload/page.tsx
+++ b/client/src/app/dashboard/upload/page.tsx
@@ -2,7 +2,8 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { useRouter } from 'next/navigation';
-import { uploadFile, listCategories } from '@/api/file';
+import { uploadFile } from '@/api/file';
+import { listCategories } from '@/api/category';
 import { Container, Typography, TextField, Button, Box, Select, MenuItem } from '@mui/material';
 
 export default function UploadPage() {

--- a/client/src/components/NavBar.tsx
+++ b/client/src/components/NavBar.tsx
@@ -31,6 +31,11 @@ export default function NavBar() {
             <Button color="inherit" component={Link} href="/dashboard/files">
               Files
             </Button>
+            {(auth.user.role === 'ADMIN' || auth.user.role === 'SUPERADMIN') && (
+              <Button color="inherit" component={Link} href="/dashboard/categories">
+                Categories
+              </Button>
+            )}
             <Button color="inherit" onClick={handleLogout}>Logout</Button>
           </React.Fragment>
         ) : (


### PR DESCRIPTION
## Summary
- create API utilities for managing categories
- add categories management page
- update upload page to use new API
- show Categories in navigation for admins
- remove unused listCategories from file API

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build` in server

------
https://chatgpt.com/codex/tasks/task_e_68418ac97ed48320ae43afd2a19904a1