### PR TITLE
Add file preview UI with icons

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@mui/icons-material": "^7.1.1",
         "@mui/material": "^7.1.1",
         "jwt-decode": "^4.0.0",
         "next": "15.3.3",
@@ -761,6 +762,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.1.1.tgz",
+      "integrity": "sha512-X37+Yc8QpEnl0sYmz+WcLFy2dWgNRzbswDzLPXG7QU1XDVlP5TPp1HXjdmCupOWLL/I9m1fyhcyZl8/HPpp/Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.1.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/material": "^7.1.1",
+    "@mui/icons-material": "^7.1.1",
     "jwt-decode": "^4.0.0",
     "next": "15.3.3",
     "react": "^19.0.0",

--- a/client/src/api/file.ts
+++ b/client/src/api/file.ts
@@ -38,3 +38,24 @@ export async function deleteFile(id: number, token: string, force = false) {
   });
   if (!res.ok) throw new Error('Failed');
 }
+
+export async function getFile(id: number, token: string) {
+  const res = await fetch(`${API_URL}/files/${id}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed');
+  return res.json();
+}
+
+export async function updateFile(id: number, filename: string, token: string) {
+  const res = await fetch(`${API_URL}/files/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ filename }),
+  });
+  if (!res.ok) throw new Error('Failed');
+  return res.json();
+}

--- a/client/src/app/dashboard/files/[id]/page.tsx
+++ b/client/src/app/dashboard/files/[id]/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/context/AuthContext';
+import { getFile, downloadFile, deleteFile, updateFile } from '@/api/file';
+import { Container, Box, Typography, Button } from '@mui/material';
+
+export default function FilePreviewPage({ params }: any) {
+  const { auth } = useAuth();
+  const router = useRouter();
+  const [file, setFile] = useState<any | null>(null);
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!auth.user) {
+      router.replace('/login');
+    } else {
+      getFile(parseInt(params.id), auth.token || '')
+        .then(setFile)
+        .catch(() => {});
+      downloadFile(parseInt(params.id), auth.token || '')
+        .then((blob) => setUrl(URL.createObjectURL(blob)))
+        .catch(() => {});
+    }
+  }, [auth, params.id, router]);
+
+  if (!auth.user || !file) return null;
+
+  const doDownload = async () => {
+    const blob = await downloadFile(file.id, auth.token || '');
+    const durl = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = durl;
+    a.download = file.filename;
+    a.click();
+    window.URL.revokeObjectURL(durl);
+  };
+
+  const doDelete = async () => {
+    if (confirm('Delete file?')) {
+      await deleteFile(
+        file.id,
+        auth.token || '',
+        auth.user!.role === 'SUPERADMIN'
+      );
+      router.push('/dashboard/files');
+    }
+  };
+
+  const doUpdate = async () => {
+    const value = prompt('New name', file.filename);
+    if (value && value !== file.filename) {
+      const updated = await updateFile(file.id, value, auth.token || '');
+      setFile(updated);
+    }
+  };
+
+  return (
+    <Container sx={{ mt: 4, display: 'flex', gap: 2 }}>
+      <Box sx={{ width: '70%' }}>
+        {url && (
+          <iframe src={url} style={{ width: '100%', height: '80vh' }} />
+        )}
+      </Box>
+      <Box sx={{ width: '30%', display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Typography variant="h6">{file.filename}</Typography>
+        <Typography>Created: {new Date(file.createdAt).toLocaleString()}</Typography>
+        <Typography>
+          Categories: {file.categories.map((c: any) => c.category.name).join(', ')}
+        </Typography>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          <Button variant="contained" onClick={doDownload}>Download</Button>
+          <Button variant="contained" onClick={doUpdate}>Update</Button>
+          {(auth.user!.role === 'ADMIN' || auth.user!.role === 'SUPERADMIN') && (
+            <Button variant="contained" color="error" onClick={doDelete}>
+              Delete
+            </Button>
+          )}
+        </Box>
+      </Box>
+    </Container>
+  );
+}

--- a/client/src/app/dashboard/files/page.tsx
+++ b/client/src/app/dashboard/files/page.tsx
@@ -3,7 +3,20 @@ import { useEffect, useState } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { listFiles, downloadFile, deleteFile } from '@/api/file';
 import { useRouter } from 'next/navigation';
-import { Container, Typography, TextField, Box, List, ListItem, ListItemText, Button } from '@mui/material';
+import {
+  Container,
+  Typography,
+  TextField,
+  Box,
+  List,
+  ListItem,
+  ListItemText,
+  Button,
+  ListItemIcon,
+} from '@mui/material';
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
+import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import ArticleIcon from '@mui/icons-material/Article';
 
 export default function FilesPage() {
   const { auth } = useAuth();
@@ -26,6 +39,12 @@ export default function FilesPage() {
     setFiles(res);
   };
 
+  const iconFor = (name: string) => {
+    if (name.toLowerCase().endsWith('.pdf')) return <PictureAsPdfIcon />;
+    if (name.toLowerCase().endsWith('.txt')) return <ArticleIcon />;
+    return <InsertDriveFileIcon />;
+  };
+
   return (
     <Container sx={{ mt: 4 }}>
       <Typography variant="h5" gutterBottom>
@@ -38,7 +57,9 @@ export default function FilesPage() {
       <List>
         {files.map((f) => (
           <ListItem key={f.id}>
+            <ListItemIcon>{iconFor(f.filename)}</ListItemIcon>
             <ListItemText primary={f.filename} secondary={f.categories.map((c: any) => c.category.name).join(', ')} />
+            <Button onClick={() => router.push(`/dashboard/files/${f.id}`)}>Preview</Button>
             <Button onClick={async () => {
               const blob = await downloadFile(f.id, auth.token || '');
               const url = window.URL.createObjectURL(blob);

--- a/server/controllers/FileController.ts
+++ b/server/controllers/FileController.ts
@@ -23,6 +23,23 @@ export class FileController {
     res.json(files);
   }
 
+  static async get(req: Request, res: Response): Promise<void> {
+    const id = parseInt(req.params.id);
+    const file = await FileService.get(id);
+    if (!file) {
+      res.status(404).end();
+      return;
+    }
+    res.json(file);
+  }
+
+  static async update(req: Request, res: Response): Promise<void> {
+    const id = parseInt(req.params.id);
+    const { filename } = req.body;
+    const file = await FileService.update(id, filename);
+    res.json(file);
+  }
+
   static async download(req: Request, res: Response): Promise<void> {
     const id = parseInt(req.params.id);
     const result = await FileService.download(id);

--- a/server/route/FileRoutes.ts
+++ b/server/route/FileRoutes.ts
@@ -50,6 +50,8 @@ router.post('/upload', authMiddleware as any, upload.single('file'), FileControl
  */
 router.get('/', authMiddleware as any, FileController.list);
 router.get('/:id/download', authMiddleware as any, FileController.download);
+router.get('/:id', authMiddleware as any, FileController.get);
+router.put('/:id', authMiddleware as any, FileController.update);
 router.delete('/:id', authMiddleware as any, FileController.delete);
 
 /**

--- a/server/services/FileService.ts
+++ b/server/services/FileService.ts
@@ -46,6 +46,10 @@ export class FileService {
     return { file, data };
   }
 
+  static async update(id: number, filename: string) {
+    return prisma.file.update({ where: { id }, data: { filename } });
+  }
+
   static async softDelete(id: number) {
     await prisma.file.update({
       where: { id },


### PR DESCRIPTION
## Summary
- show icons for files by extension
- add preview page with metadata and actions
- implement server routes for file info/update
- support renaming files
- include @mui/icons-material dependency

## Testing
- `npm run build` in `server`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_68429d05579c8320a2ee4a9c6a8da7c0