### PR TITLE
Fix text preview missing content

### DIFF
--- a/server/controllers/FileController.ts
+++ b/server/controllers/FileController.ts
@@ -1,6 +1,28 @@
 import { Request, Response } from 'express';
 import { FileService } from '../services/FileService';
 
+function mimeType(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'txt':
+    case 'text':
+      return 'text/plain';
+    case 'pdf':
+      return 'application/pdf';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    case 'png':
+      return 'image/png';
+    case 'gif':
+      return 'image/gif';
+    case 'svg':
+      return 'image/svg+xml';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
 export class FileController {
   static async upload(req: Request, res: Response): Promise<void> {
     const file = (req as any).file as Express.Multer.File | undefined;
@@ -47,6 +69,7 @@ export class FileController {
       res.status(404).end();
       return;
     }
+    res.setHeader('Content-Type', mimeType(result.file.filename));
     res.setHeader('Content-Disposition', `attachment; filename="${result.file.filename}"`);
     res.send(Buffer.from(result.data));
   }


### PR DESCRIPTION
## Summary
- map basic file extensions to MIME types
- set `Content-Type` header when serving downloads

## Testing
- `npm run build` in `server`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6842a9bca3908320a76011c447ef4f06