### PR TITLE
Fix preview rendering

### DIFF
--- a/client/src/app/dashboard/files/[id]/page.tsx
+++ b/client/src/app/dashboard/files/[id]/page.tsx
@@ -10,13 +10,18 @@ export default function FilePreviewPage({ params }: any) {
   const router = useRouter();
   const [file, setFile] = useState<any | null>(null);
   const [url, setUrl] = useState<string | null>(null);
+  const [ext, setExt] = useState<string>('');
 
   useEffect(() => {
     if (!auth.user) {
       router.replace('/login');
     } else {
       getFile(parseInt(params.id), auth.token || '')
-        .then(setFile)
+        .then((data) => {
+          setFile(data);
+          const e = data.filename.split('.').pop()?.toLowerCase() || '';
+          setExt(e);
+        })
         .catch(() => {});
       downloadFile(parseInt(params.id), auth.token || '')
         .then((blob) => setUrl(URL.createObjectURL(blob)))
@@ -59,7 +64,13 @@ export default function FilePreviewPage({ params }: any) {
     <Container sx={{ mt: 4, display: 'flex', gap: 2 }}>
       <Box sx={{ width: '70%' }}>
         {url && (
-          <iframe src={url} style={{ width: '100%', height: '80vh' }} />
+          ext === 'pdf' || ext === 'txt' ? (
+            <iframe src={url} style={{ width: '100%', height: '80vh' }} />
+          ) : ext === 'png' || ext === 'jpg' || ext === 'jpeg' || ext === 'gif' || ext === 'svg' ? (
+            <img src={url} style={{ maxWidth: '100%', maxHeight: '80vh' }} />
+          ) : (
+            <Typography>Cannot preview this file type</Typography>
+          )
         )}
       </Box>
       <Box sx={{ width: '30%', display: 'flex', flexDirection: 'column', gap: 2 }}>

--- a/server/controllers/FileController.ts
+++ b/server/controllers/FileController.ts
@@ -70,7 +70,7 @@ export class FileController {
       return;
     }
     res.setHeader('Content-Type', mimeType(result.file.filename));
-    res.setHeader('Content-Disposition', `attachment; filename="${result.file.filename}"`);
+    res.setHeader('Content-Disposition', `inline; filename="${result.file.filename}"`);
     res.send(Buffer.from(result.data));
   }
 


### PR DESCRIPTION
## Summary
- show images and text/pdf appropriately in preview
- send files as `inline` instead of `attachment` in backend

## Testing
- `npm run build` in `server`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6842ac516d2c83209e1085cc6aba9747