### PR TITLE
Fix file preview not working

### DIFF
--- a/client/src/app/dashboard/files/[id]/page.tsx
+++ b/client/src/app/dashboard/files/[id]/page.tsx
@@ -13,6 +13,7 @@ export default function FilePreviewPage({ params }: any) {
   const [ext, setExt] = useState<string>('');
 
   useEffect(() => {
+    let objectUrl: string | null = null;
     if (!auth.user) {
       router.replace('/login');
     } else {
@@ -21,12 +22,22 @@ export default function FilePreviewPage({ params }: any) {
           setFile(data);
           const e = data.filename.split('.').pop()?.toLowerCase() || '';
           setExt(e);
+          if (
+            ['pdf', 'txt', 'png', 'jpg', 'jpeg', 'gif', 'svg'].includes(e)
+          ) {
+            return downloadFile(parseInt(params.id), auth.token || '').then(
+              (blob) => {
+                objectUrl = URL.createObjectURL(blob);
+                setUrl(objectUrl);
+              }
+            );
+          }
         })
         .catch(() => {});
-      downloadFile(parseInt(params.id), auth.token || '')
-        .then((blob) => setUrl(URL.createObjectURL(blob)))
-        .catch(() => {});
     }
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
   }, [auth, params.id, router]);
 
   if (!auth.user || !file) return null;

--- a/server/controllers/FileController.ts
+++ b/server/controllers/FileController.ts
@@ -70,7 +70,7 @@ export class FileController {
       return;
     }
     res.setHeader('Content-Type', mimeType(result.file.filename));
-    res.setHeader('Content-Disposition', `inline; filename="${result.file.filename}"`);
+    // Allow browser preview without forcing download
     res.send(Buffer.from(result.data));
   }
 


### PR DESCRIPTION
## Summary
- clean `Content-Disposition` header for downloaded files
- only fetch preview content for supported file types and revoke object URLs when unmounted

## Testing
- `npm run build` in `server`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6842b05c43ac8320a56e40e30f021510