### PR TITLE
Fix PDF viewer

### DIFF
--- a/client/src/app/dashboard/files/[id]/page.tsx
+++ b/client/src/app/dashboard/files/[id]/page.tsx
@@ -5,6 +5,10 @@ import { useAuth } from '@/context/AuthContext';
 import { getFile, deleteFile, updateFile, fileDownloadUrl } from '@/api/file';
 import { Container, Box, Typography, Button } from '@mui/material';
 import DocViewer, { DocViewerRenderers } from 'react-doc-viewer';
+import { pdfjs } from 'react-pdf';
+
+// Explicitly set PDF.js worker path so that previews work in Next.js
+pdfjs.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.mjs`;
 
 export default function FilePreviewPage({ params }: any) {
   const { auth } = useAuth();


### PR DESCRIPTION
## Summary
- configure pdf.js worker for `react-doc-viewer` so the preview page works with Next.js

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6842ba020ffc83209f64d61e1e3fc24b