### PR TITLE
Fix auth token parsing

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,8 @@ import { swaggerSpec } from './swagger';
 
 dotenv.config();
 const app = express();
+// Use Node's simple query parser so JWT tokens in query params are read correctly
+app.set('query parser', 'simple');
 const PORT = process.env.PORT || 5000;
 
 // Middleware

--- a/server/route/FileRoutes.ts
+++ b/server/route/FileRoutes.ts
@@ -49,25 +49,16 @@ router.post('/upload', authMiddleware as any, upload.single('file'), FileControl
  *         description: List files
  */
 router.get('/', authMiddleware as any, FileController.list);
+
+// Category routes should appear before dynamic :id routes to avoid conflicts
+router.get('/categories', authMiddleware as any, CategoryController.list);
+router.post('/categories', authMiddleware as any, CategoryController.create);
+router.put('/categories/:id', authMiddleware as any, CategoryController.update);
+router.delete('/categories/:id', authMiddleware as any, CategoryController.remove);
+
 router.get('/:id/download', authMiddleware as any, FileController.download);
 router.get('/:id', authMiddleware as any, FileController.get);
 router.put('/:id', authMiddleware as any, FileController.update);
 router.delete('/:id', authMiddleware as any, FileController.delete);
-
-/**
- * @swagger
- * /api/categories:
- *   get:
- *     summary: List categories
- *     tags: [Category]
- *     responses:
- *       200:
- *         description: List
- */
-router.get('/categories', authMiddleware as any, CategoryController.list);
-
-router.post('/categories', authMiddleware as any, CategoryController.create);
-router.put('/categories/:id', authMiddleware as any, CategoryController.update);
-router.delete('/categories/:id', authMiddleware as any, CategoryController.remove);
 
 export default router;

--- a/server/utils/authMiddleware.ts
+++ b/server/utils/authMiddleware.ts
@@ -4,9 +4,23 @@ import { verifyToken } from './auth';
 export function authMiddleware(req: Request, res: Response, next: NextFunction) {
   const auth = req.headers.authorization;
   let token: string | null = null;
-  if (auth) token = auth.split(' ')[1];
-  else if (typeof req.query.token === 'string') token = req.query.token;
-  if (!token) return res.status(401).json({ error: 'Unauthorized' });
+
+  if (auth && auth.toLowerCase().startsWith('bearer ')) {
+    token = auth.slice(7);
+  }
+
+  if (!token) {
+    const rawQuery = req.originalUrl.split('?')[1];
+    if (rawQuery) {
+      const params = new URLSearchParams(rawQuery);
+      token = params.get('token');
+    }
+  }
+
+  if (!token) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
   try {
     const payload = verifyToken(token);
     (req as any).userId = payload.userId;


### PR DESCRIPTION
## Summary
- ensure Express uses simple query parser
- improve auth middleware token extraction for array values
- also check raw query string when header missing

## Testing
- `npm run build` in `server`
- `npm run build` in `client` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_6842c347dfc88320b538c1727af5b634