### PR TITLE
Fix dashboard redirect logic

### DIFF
--- a/client/src/app/dashboard/categories/page.tsx
+++ b/client/src/app/dashboard/categories/page.tsx
@@ -20,19 +20,21 @@ import {
 } from '@mui/material';
 
 export default function CategoriesPage() {
-  const { auth } = useAuth();
+  const { auth, initialized } = useAuth();
   const router = useRouter();
   const [categories, setCategories] = useState<any[]>([]);
   const [name, setName] = useState('');
 
   useEffect(() => {
+    if (!initialized) return;
     if (!auth.user) {
       router.replace('/login');
     } else {
       listCategories(auth.token || '').then(setCategories).catch(() => {});
     }
-  }, [auth, router]);
+  }, [initialized, auth, router]);
 
+  if (!initialized) return null;
   if (!auth.user) return null;
 
   const refresh = async () => {

--- a/client/src/app/dashboard/files/[id]/page.tsx
+++ b/client/src/app/dashboard/files/[id]/page.tsx
@@ -25,7 +25,7 @@ import mammoth from "mammoth";
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
 
 export default function FilePreviewPage() {
-  const { auth } = useAuth();
+  const { auth, initialized } = useAuth();
   const params = useParams();
   const router = useRouter();
 
@@ -43,6 +43,7 @@ export default function FilePreviewPage() {
   const idNum = parseInt(idStr, 10);
 
   useEffect(() => {
+    if (!initialized) return;
     if (!auth.user) {
       router.replace("/login");
       return;
@@ -115,7 +116,10 @@ export default function FilePreviewPage() {
         setError("Не удалось загрузить файл");
       }
     })();
-  }, [auth, idStr, idNum, router]);
+  }, [initialized, auth, idStr, idNum, router]);
+
+  if (!initialized) return null;
+  if (!auth.user) return null;
 
   if (error) {
     return (

--- a/client/src/app/dashboard/files/page.tsx
+++ b/client/src/app/dashboard/files/page.tsx
@@ -15,12 +15,13 @@ import {
 } from "@mui/material";
 
 export default function FilesPage() {
-  const { auth } = useAuth();
+  const { auth, initialized } = useAuth();
   const router = useRouter();
   const [query, setQuery] = useState("");
   const [files, setFiles] = useState<any[]>([]);
 
   useEffect(() => {
+    if (!initialized) return;
     if (!auth.user) {
       router.replace("/login");
     } else {
@@ -28,8 +29,9 @@ export default function FilesPage() {
         .then(setFiles)
         .catch(() => {});
     }
-  }, [auth, router]);
+  }, [initialized, auth, router]);
 
+  if (!initialized) return null;
   if (!auth.user) return null;
 
   const search = async () => {

--- a/client/src/app/dashboard/page.tsx
+++ b/client/src/app/dashboard/page.tsx
@@ -5,15 +5,16 @@ import { useAuth } from '@/context/AuthContext';
 import { Typography, Container } from '@mui/material';
 
 export default function DashboardPage() {
-  const { auth } = useAuth();
+  const { auth, initialized } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
-    if (!auth.user) {
+    if (initialized && !auth.user) {
       router.replace('/login');
     }
-  }, [auth.user, router]);
+  }, [initialized, auth.user, router]);
 
+  if (!initialized) return null;
   if (!auth.user) return null;
 
   return (

--- a/client/src/app/dashboard/upload/page.tsx
+++ b/client/src/app/dashboard/upload/page.tsx
@@ -7,20 +7,22 @@ import { listCategories } from '@/api/category';
 import { Container, Typography, TextField, Button, Box, Select, MenuItem } from '@mui/material';
 
 export default function UploadPage() {
-  const { auth } = useAuth();
+  const { auth, initialized } = useAuth();
   const router = useRouter();
   const [file, setFile] = useState<File | null>(null);
   const [categories, setCategories] = useState<any[]>([]);
   const [selected, setSelected] = useState<number[]>([]);
 
   useEffect(() => {
+    if (!initialized) return;
     if (!auth.user) {
       router.replace('/login');
     } else {
       listCategories(auth.token || '').then(setCategories).catch(() => {});
     }
-  }, [auth, router]);
+  }, [initialized, auth, router]);
 
+  if (!initialized) return null;
   if (!auth.user) return null;
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -16,15 +16,18 @@ interface AuthState {
 interface AuthContextType {
   auth: AuthState;
   setAuth: (value: AuthState) => void;
+  initialized: boolean;
 }
 
 const AuthContext = createContext<AuthContextType>({
   auth: { token: null, user: null },
   setAuth: () => {},
+  initialized: false,
 });
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [auth, setAuthState] = useState<AuthState>({ token: null, user: null });
+  const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
     const token = localStorage.getItem('token');
@@ -32,6 +35,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     if (token && user) {
       setAuthState({ token, user: JSON.parse(user) });
     }
+    setInitialized(true);
   }, []);
 
   const setAuth = (value: AuthState) => {
@@ -46,7 +50,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ auth, setAuth }}>
+    <AuthContext.Provider value={{ auth, setAuth, initialized }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- preserve login state from localStorage with `initialized` flag in `AuthContext`
- wait for auth initialization before redirecting on dashboard pages

## Testing
- `npm --prefix client run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6847cba1d9208320bb6e50da76396a51