### PR TITLE
Fix hydration mismatch in layout

### DIFF
--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import NavBar from "@/components/NavBarClient";
+import NavBar from "@/components/NavBar";
 import { AuthProvider } from "@/context/AuthContext";
 import ThemeRegistry from "@/components/ThemeRegistry";
 

--- a/client/src/components/NavBarClient.tsx
+++ b/client/src/components/NavBarClient.tsx
@@ -1,6 +1,0 @@
-'use client';
-import dynamic from 'next/dynamic';
-const NavBar = dynamic(() => import('./NavBar'), { ssr: false });
-export default function NavBarClient() {
-  return <NavBar />;
-}


### PR DESCRIPTION
## Summary
- fix hydration errors by importing `NavBar` directly in the root layout
- remove unused `NavBarClient` wrapper

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` in `server` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6847ddcef84c8320ade90d27bd20610a