### PR TITLE
Fix MUI hydration by adding emotion cache

### DIFF
--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import NavBar from "@/components/NavBarClient";
+import NavBar from "@/components/NavBar";
 import { AuthProvider } from "@/context/AuthContext";
 import ThemeRegistry from "@/components/ThemeRegistry";
 

--- a/client/src/components/NavBarClient.tsx
+++ b/client/src/components/NavBarClient.tsx
@@ -1,6 +1,0 @@
-'use client';
-import dynamic from 'next/dynamic';
-const NavBar = dynamic(() => import('./NavBar'), { ssr: false });
-export default function NavBarClient() {
-  return <NavBar />;
-}

--- a/client/src/components/ThemeRegistry/EmotionCache.tsx
+++ b/client/src/components/ThemeRegistry/EmotionCache.tsx
@@ -1,0 +1,85 @@
+'use client';
+import * as React from 'react';
+import createCache from '@emotion/cache';
+import { useServerInsertedHTML } from 'next/navigation';
+import { CacheProvider as DefaultCacheProvider } from '@emotion/react';
+import type { EmotionCache, Options as OptionsOfCreateCache } from '@emotion/cache';
+
+export type NextAppDirEmotionCacheProviderProps = {
+  options: Omit<OptionsOfCreateCache, 'insertionPoint'>;
+  CacheProvider?: React.ElementType<{ value: EmotionCache }>;
+  children: React.ReactNode;
+};
+
+export default function NextAppDirEmotionCacheProvider(
+  props: NextAppDirEmotionCacheProviderProps,
+) {
+  const { options, CacheProvider = DefaultCacheProvider, children } = props;
+
+  const [registry] = React.useState(() => {
+    const cache = createCache(options);
+    cache.compat = true;
+    const prevInsert = cache.insert;
+    let inserted: { name: string; isGlobal: boolean }[] = [];
+    cache.insert = (...args) => {
+      const [selector, serialized] = args as [string | undefined, { name: string }];
+      if (cache.inserted[serialized.name] === undefined) {
+        inserted.push({
+          name: serialized.name,
+          isGlobal: !selector,
+        });
+      }
+      return prevInsert(...args);
+    };
+    const flush = () => {
+      const prevInserted = inserted;
+      inserted = [];
+      return prevInserted;
+    };
+    return { cache, flush };
+  });
+
+  useServerInsertedHTML(() => {
+    const inserted = registry.flush();
+    if (inserted.length === 0) {
+      return null;
+    }
+    let styles = '';
+    let dataEmotionAttribute = registry.cache.key;
+
+    const globals: { name: string; style: string }[] = [];
+
+    inserted.forEach(({ name, isGlobal }) => {
+      const style = registry.cache.inserted[name];
+
+      if (typeof style !== 'boolean') {
+        if (isGlobal) {
+          globals.push({ name, style });
+        } else {
+          styles += style;
+          dataEmotionAttribute += ` ${name}`;
+        }
+      }
+    });
+
+    return (
+      <React.Fragment>
+        {globals.map(({ name, style }) => (
+          <style
+            key={name}
+            data-emotion={`${registry.cache.key}-global ${name}`}
+            dangerouslySetInnerHTML={{ __html: style }}
+          />
+        ))}
+        {styles && (
+          <style
+            data-emotion={dataEmotionAttribute}
+            dangerouslySetInnerHTML={{ __html: styles }}
+          />
+        )}
+      </React.Fragment>
+    );
+  });
+
+  return <CacheProvider value={registry.cache}>{children}</CacheProvider>;
+}

--- a/client/src/components/ThemeRegistry/ThemeRegistry.tsx
+++ b/client/src/components/ThemeRegistry/ThemeRegistry.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import NextAppDirEmotionCacheProvider from './EmotionCache';
 
 export default function ThemeRegistry({ children }: { children: React.ReactNode }) {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
@@ -10,17 +11,17 @@ export default function ThemeRegistry({ children }: { children: React.ReactNode 
   const theme = React.useMemo(
     () =>
       createTheme({
-        palette: {
-          mode: prefersDarkMode ? 'dark' : 'light',
-        },
+        palette: { mode: prefersDarkMode ? 'dark' : 'light' },
       }),
-    [prefersDarkMode]
+    [prefersDarkMode],
   );
 
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      {children}
-    </ThemeProvider>
+    <NextAppDirEmotionCacheProvider options={{ key: 'mui' }}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </NextAppDirEmotionCacheProvider>
   );
 }

--- a/client/src/components/ThemeRegistry/index.ts
+++ b/client/src/components/ThemeRegistry/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ThemeRegistry';


### PR DESCRIPTION
## Summary
- use an Emotion cache provider to support MUI SSR styles
- rename `ThemeRegistry` component into its own folder with emotion cache helper

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` in `server`

------
https://chatgpt.com/codex/tasks/task_e_6847ddcef84c8320ade90d27bd20610a