### PR TITLE
Enable superadmin to manage user roles

### DIFF
--- a/server/controllers/UserController.ts
+++ b/server/controllers/UserController.ts
@@ -43,4 +43,32 @@ export class UserController {
       res.status(401).json({ error: (err as Error).message });
     }
   }
+
+  static async list(req: Request, res: Response): Promise<void> {
+    if ((req as any).userRole !== 'SUPERADMIN') {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const users = await UserService.list();
+    res.json(users);
+  }
+
+  static async setRole(req: Request, res: Response): Promise<void> {
+    if ((req as any).userRole !== 'SUPERADMIN') {
+      res.status(403).json({ error: 'Forbidden' });
+      return;
+    }
+    const id = parseInt(req.params.id, 10);
+    const role = (req.body as any).role as string | undefined;
+    if (!role) {
+      res.status(400).json({ error: 'Role required' });
+      return;
+    }
+    try {
+      const user = await UserService.setRole(id, role);
+      res.json(user);
+    } catch (err) {
+      res.status(400).json({ error: (err as Error).message });
+    }
+  }
 }

--- a/server/route/UserRoutes.ts
+++ b/server/route/UserRoutes.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { UserController } from '../controllers/UserController';
+import { authMiddleware } from '../utils/authMiddleware';
 
 const router = Router();
 
@@ -57,5 +58,53 @@ router.post('/register', UserController.register);
  *         description: Successful login
  */
 router.post('/login', UserController.login);
+
+/**
+ * @swagger
+ * /api/user:
+ *   get:
+ *     summary: List users
+ *     tags: [User]
+ *     responses:
+ *       200:
+ *         description: Users list
+ *       403:
+ *         description: Forbidden
+ */
+router.get('/', authMiddleware as any, UserController.list);
+
+/**
+ * @swagger
+ * /api/user/{id}/role:
+ *   put:
+ *     summary: Update user role
+ *     tags: [User]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: User ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - role
+ *             properties:
+ *               role:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Updated user
+ *       400:
+ *         description: Invalid request
+ *       403:
+ *         description: Forbidden
+ */
+router.put('/:id/role', authMiddleware as any, UserController.setRole);
 
 export default router;

--- a/server/services/UserService.ts
+++ b/server/services/UserService.ts
@@ -83,4 +83,28 @@ export class UserService {
     const { password: _p, roleId: _roleId, role, ...userWithoutPassword } = user;
     return { ...userWithoutPassword, role: role.role };
   }
+
+  // Список всех пользователей с ролями
+  static async list() {
+    const users = await prisma.user.findMany({ include: { role: true }, orderBy: { id: 'asc' } });
+    return users.map((u: any) => {
+      const { password, roleId, role, ...rest } = u;
+      return { ...rest, role: role.role };
+    });
+  }
+
+  // Изменить роль пользователя
+  static async setRole(userId: number, roleName: string) {
+    const role = await prisma.role.findUnique({ where: { role: roleName } });
+    if (!role) {
+      throw new Error('Role not found');
+    }
+    const user = await prisma.user.update({
+      where: { id: userId },
+      data: { roleId: role.id },
+      include: { role: true },
+    });
+    const { password, roleId, role: r, ...rest } = user;
+    return { ...rest, role: r.role };
+  }
 }


### PR DESCRIPTION
## Summary
- add list and setRole methods in `UserService`
- allow superadmin to fetch all users and change their role via `UserController`
- expose GET `/api/user` and PUT `/api/user/:id/role` routes
- document new superadmin endpoints in Swagger comments
- build server to ensure TypeScript compiles

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68590ba3b740832088810ccfd254770d